### PR TITLE
TRE-1146 Make auto registration configurable, default false

### DIFF
--- a/src/aws_schema_registry/serde.py
+++ b/src/aws_schema_registry/serde.py
@@ -51,12 +51,14 @@ class KafkaSerializer:
         client: SchemaRegistryClient,
         is_key: bool = False,
         compatibility_mode: CompatibilityMode = 'BACKWARD',
-        schema_naming_strategy: SchemaNamingStrategy = topic_name_strategy
+        schema_naming_strategy: SchemaNamingStrategy = topic_name_strategy,
+        auto_register_schema: bool = False
     ):
         self.client = client
         self.is_key = is_key
         self.compatibility_mode: CompatibilityMode = compatibility_mode
         self.schema_naming_strategy = schema_naming_strategy
+        self.auto_register_schema = auto_register_schema
 
     def serialize(self, topic: str, data_and_schema: DataAndSchema):
         if data_and_schema is None:
@@ -73,12 +75,10 @@ class KafkaSerializer:
     def _get_schema_version(self, topic: str, schema: Schema) -> SchemaVersion:
         schema_name = self.schema_naming_strategy(topic, self.is_key, schema)
         LOG.info('Fetching schema %s...', schema_name)
-        return self.client.get_or_register_schema_version(
-            definition=str(schema),
-            schema_name=schema_name,
-            data_format=schema.data_format,
-            compatibility_mode=self.compatibility_mode
-        )
+        return self.client.get_or_register_schema_version(definition=str(schema), schema_name=schema_name,
+                                                          data_format=schema.data_format,
+                                                          compatibility_mode=self.compatibility_mode,
+                                                          auto_register_schema=self.auto_register_schema)
 
 
 class KafkaDeserializer:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,15 +88,15 @@ def test_get_or_register_schema_version_default_does_not_create_schema(client, g
         side_effect=SchemaRegistryException(
             Exception(SCHEMA_NOT_FOUND_MSG)
         ))
-    stub_create_schema(glue_client)
-    stub_get_schema_version(glue_client, 'AVRO')
+    mock_create_schema(glue_client)
+    mock_get_schema_version(glue_client, 'AVRO')
 
     with pytest.raises(SchemaRegistryException) as expected_exception:
         get_or_register_schema_version(client, 'AVRO', False)
 
     assert SCHEMA_NOT_FOUND_MSG in str(expected_exception)
 
-    stub_get_schema_version(glue_client, 'JSON')
+    mock_get_schema_version(glue_client, 'JSON')
 
     with pytest.raises(SchemaRegistryException) as expected_exception:
         get_or_register_schema_version(client, 'JSON', False)
@@ -109,14 +109,14 @@ def test_get_or_register_schema_version_creates_schema(client, glue_client):
         side_effect=SchemaRegistryException(
             Exception(SCHEMA_NOT_FOUND_MSG)
         ))
-    stub_create_schema(glue_client)
-    stub_get_schema_version(glue_client, 'AVRO')
+    mock_create_schema(glue_client)
+    mock_get_schema_version(glue_client, 'AVRO')
 
     version = get_or_register_schema_version(client, 'AVRO', True)
 
     assert version.version_id == SCHEMA_VERSION_ID
 
-    stub_get_schema_version(glue_client, 'JSON')
+    mock_get_schema_version(glue_client, 'JSON')
 
     version = get_or_register_schema_version(client, 'JSON', True)
 
@@ -130,15 +130,15 @@ def test_get_or_register_schema_version_default_does_not_register_version(
         side_effect=SchemaRegistryException(
             Exception(SCHEMA_VERSION_NOT_FOUND_MSG)
         ))
-    stub_register_schema_version(glue_client)
-    stub_get_schema_version(glue_client, 'AVRO')
+    mock_register_schema_version(glue_client)
+    mock_get_schema_version(glue_client, 'AVRO')
 
     with pytest.raises(SchemaRegistryException) as expected_exception:
         get_or_register_schema_version(client, 'AVRO', False)
 
     assert SCHEMA_VERSION_NOT_FOUND_MSG in str(expected_exception)
 
-    stub_get_schema_version(glue_client, 'JSON')
+    mock_get_schema_version(glue_client, 'JSON')
 
     with pytest.raises(SchemaRegistryException) as expected_exception:
         get_or_register_schema_version(client, 'JSON', False)
@@ -153,14 +153,14 @@ def test_get_or_register_schema_version_registers_version(
         side_effect=SchemaRegistryException(
             Exception(SCHEMA_VERSION_NOT_FOUND_MSG)
         ))
-    stub_register_schema_version(glue_client)
-    stub_get_schema_version(glue_client, 'AVRO')
+    mock_register_schema_version(glue_client)
+    mock_get_schema_version(glue_client, 'AVRO')
 
     version = get_or_register_schema_version(client, 'AVRO', True)
 
     assert version.version_id == SCHEMA_VERSION_ID
 
-    stub_get_schema_version(glue_client, 'JSON')
+    mock_get_schema_version(glue_client, 'JSON')
 
     version = get_or_register_schema_version(client, 'JSON', True)
 
@@ -261,7 +261,7 @@ def test_create_schema(client, glue_client, data_format):
     assert version_id == schema_version_id
 
 
-def stub_get_schema_version(glue_client, data_format):
+def mock_get_schema_version(glue_client, data_format):
     glue_client.get_schema_version = Mock(return_value={
         'SchemaVersionId': str(SCHEMA_VERSION_ID),
         'SchemaDefinition': SCHEMA_DEF,
@@ -272,7 +272,7 @@ def stub_get_schema_version(glue_client, data_format):
     })
 
 
-def stub_register_schema_version(glue_client):
+def mock_register_schema_version(glue_client):
     glue_client.register_schema_version = Mock(return_value={
         'SchemaVersionId': str(SCHEMA_VERSION_ID),
         'VersionNumber': 123,
@@ -280,7 +280,7 @@ def stub_register_schema_version(glue_client):
     })
 
 
-def stub_create_schema(glue_client):
+def mock_create_schema(glue_client):
     glue_client.create_schema = Mock(return_value={
         'RegistryName': REGISTRY_NAME,
         'SchemaName': SCHEMA_NAME,


### PR DESCRIPTION
Auto registration currently happens if the schema version or the whole schema is not found in registry. We want the option to disable this, which the Java library offers